### PR TITLE
REComposeViewController: use keyWindow instead of delegate.window

### DIFF
--- a/REComposeViewController/REComposeViewController.m
+++ b/REComposeViewController/REComposeViewController.m
@@ -54,7 +54,7 @@
 
 - (void)loadView
 {
-    UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
+    UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
     self.view = [[UIView alloc] initWithFrame:rootViewController.view.bounds];
     self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 }
@@ -125,7 +125,7 @@
 
 - (void)presentFromRootViewController
 {
-    UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
+    UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
     [self presentFromViewController:rootViewController];
 }
 


### PR DESCRIPTION
I'm working on a project, where delegate.window isn't set.
UIApplication.keyWindow should be more generic & work for everybody.

Thanks for cool pod, really useful & convenient!
